### PR TITLE
Reduced syntactic redundancy in Ravel.module by deriving module name from path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Business logic sits in plain old node.js modules, which are generally not networ
 *modules/cities.js*
 
     // Ravel error and logging services $E and $L can
-    // be injected alongside your other modules and
+    // be injected alongside your own modules and
     // npm dependencies. No require statements or
     // relative paths!
     module.exports = function($E, $L, async) {
@@ -87,8 +87,9 @@ To register and name your module, we need a top-level *app.js* file:
     var Ravel = new require('ravel')();
     //...we'll initialize Ravel with some important parameters later
 
-    // supply the name for the module, and its path
-    Ravel.module('cities', './modules/cities');
+    // supply the path to this module. you'll be able to inject
+    // it into other modules using the name 'cities'
+    Ravel.module('./modules/cities');
 
 ### Then, define a Resource
 
@@ -142,7 +143,7 @@ Like before, we need to register our resource:
     var Ravel = new require('ravel')();
     //...we're still getting to this part
 
-    Ravel.module('cities', './modules/cities');
+    Ravel.module('./modules/cities');
     // Specify the base endpoint (/cities), and the location of the resource module
     Ravel.resource('./resources/city');
 
@@ -176,7 +177,7 @@ Once again, register the routes:
     Ravel.set('express view engine', 'ejs');
     //...we're still getting to this part
 
-    Ravel.module('cities', './modules/cities');
+    Ravel.module('./modules/cities');
     Ravel.resource('./resources/city');
     //Just specify the location of the routes and Ravel will load them
     Ravel.routes('./routes/index_r.js');
@@ -192,7 +193,7 @@ Websocket Rooms are topic *patterns* which represent a collection of topics to w
     Ravel.set('express view engine', 'ejs');
     //...we're still getting to this part
 
-    Ravel.module('cities', './modules/cities');
+    Ravel.module('./modules/cities');
     Ravel.resource('./resources/city');
     Ravel.routes('./routes/index_r.js');
 
@@ -223,7 +224,7 @@ We've been avoiding some mandatory Ravel.set() parameters up until now, includin
     Ravel.set('redis port', 5432);
     Ravel.set('express session secret', 'a very random string');
 
-    Ravel.module('cities', './modules/cities');
+    Ravel.module('./modules/cities');
     Ravel.resource('./resources/city');
     Ravel.routes('./routes/index_r.js');
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -18,11 +18,12 @@ module.exports = function(Ravel, moduleFactories, injector) {
    * Modules should use injection to refer to other Ravel modules and NPM
    * dependencies.
    *
-   * @param {String} name The name of the module
    * @param {String} modulePath The path to the module
    *
    */
-  Ravel.module = function(name, modulePath) {
+  Ravel.module = function(modulePath) {
+    var name = path.parse(modulePath).name;
+
     //if a module with this name has already been regsitered, error out
     if (moduleFactories[name]) {
       throw new Ravel.ApplicationError.DuplicateEntry(

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -22,7 +22,7 @@ module.exports = function(Ravel, moduleFactories, injector) {
    *
    */
   Ravel.module = function(modulePath) {
-    var name = path.parse(modulePath).name;
+    var name = path.basename(modulePath, path.extname(modulePath));
 
     //if a module with this name has already been regsitered, error out
     if (moduleFactories[name]) {

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -61,7 +61,7 @@ describe('Ravel', function() {
     //stub resource
     var usersResource = function($Resource, $Rest, users) {
       $Resource.bind('/api/user');
-      
+
       $Resource.getAll(function(req, res) {
         users.getAllUsers(function(err, result) {
           $Rest.buildRestResponse(req, res, err, result);
@@ -75,7 +75,7 @@ describe('Ravel', function() {
       });
     };
 
-    Ravel.module('users', 'users');
+    Ravel.module('users');
     mockery.registerMock(path.join(Ravel.cwd, 'users'), users);
     Ravel.resource('usersResource');
     mockery.registerMock(path.join(Ravel.cwd, 'usersResource'), usersResource);

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -85,7 +85,7 @@ describe('Ravel end-to-end test', function() {
         Ravel.set('express session secret', 'mysecret');
         Ravel.set('disable json vulnerability protection', true);
 
-        Ravel.module('users', 'users');
+        Ravel.module('users');
         mockery.registerMock(path.join(Ravel.cwd, 'users'), users);
         Ravel.resource('usersResource');
         mockery.registerMock(path.join(Ravel.cwd, 'usersResource'), usersResource);

--- a/test/util/test-injector.js
+++ b/test/util/test-injector.js
@@ -42,10 +42,10 @@ describe('Ravel', function() {
         done();
         return {};
       };
-      Ravel.module('test', 'stub1');
-      Ravel.module('test2', 'stub2');
-      mockery.registerMock(path.join(Ravel.cwd, 'stub1'), stub1);
-      mockery.registerMock(path.join(Ravel.cwd, 'stub2'), stub2);
+      Ravel.module('test');
+      Ravel.module('test2');
+      mockery.registerMock(path.join(Ravel.cwd, 'test'), stub1);
+      mockery.registerMock(path.join(Ravel.cwd, 'test2'), stub2);
       Ravel._moduleFactories['test']();
       Ravel._injector.inject({}, stub2);
     });
@@ -64,8 +64,8 @@ describe('Ravel', function() {
           method: function() {}
         };
       };
-      Ravel.module('test', 'stub');
-      mockery.registerMock(path.join(Ravel.cwd, 'stub'), stubClientModule);
+      Ravel.module('test');
+      mockery.registerMock(path.join(Ravel.cwd, 'test'), stubClientModule);
       mockery.registerMock('moment', stubMoment);
       Ravel._injector.inject({}, stubClientModule);
     });
@@ -74,8 +74,8 @@ describe('Ravel', function() {
       var stub = function(unknownModule) {
         expect(unknownModule).to.be.an('object');
       };
-      Ravel.module('test', 'stub');
-      mockery.registerMock(path.join(Ravel.cwd, 'stub'), stub);
+      Ravel.module('test');
+      mockery.registerMock(path.join(Ravel.cwd, 'test'), stub);
       try {
         Ravel._injector.inject({}, stub);
         done(new Error('It should be impossible to inject an unknown module or npm dependency'));
@@ -94,8 +94,8 @@ describe('Ravel', function() {
         expect(pseudoModule).to.equal(moduleMap.pseudoModule);
         done();
       };
-      Ravel.module('test', 'stub');
-      mockery.registerMock(path.join(Ravel.cwd, 'stub'), stub);
+      Ravel.module('test');
+      mockery.registerMock(path.join(Ravel.cwd, 'test'), stub);
       Ravel._injector.inject(moduleMap, stub);
     });
   });


### PR DESCRIPTION
Fixes #29 