### PR TITLE
Support modules with hyphenated filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Business logic sits in plain old node.js modules, which are generally not networ
       var c = ['Toronto', 'New York', 'Chicago'];
 
       Cities.getAllCities = function(callback) {
+        // pretend we used async for something here
+        // since we magically injected it above
         callback(null, c);
       };
 
@@ -90,6 +92,8 @@ To register and name your module, we need a top-level *app.js* file:
     // supply the path to this module. you'll be able to inject
     // it into other modules using the name 'cities'
     Ravel.module('./modules/cities');
+
+Note: Modules with filenames including hyphens are made available for injection via camel case  ('./modules/my-module.js' would be available as 'myModule').
 
 ### Then, define a Resource
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -23,6 +23,7 @@ module.exports = function(Ravel, moduleFactories, injector) {
    */
   Ravel.module = function(modulePath) {
     var name = path.basename(modulePath, path.extname(modulePath));
+    name = name.replace(/-([A-Za-z])/g, function (g) { return g[1].toUpperCase(); });
 
     //if a module with this name has already been regsitered, error out
     if (moduleFactories[name]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Sean McIntyre <smcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "contributors": [

--- a/test/core/test-module.js
+++ b/test/core/test-module.js
@@ -81,6 +81,18 @@ describe('Ravel', function() {
       Ravel._moduleFactories['test']();
     });
 
+    it('should convert hyphenated module names into camel case automatically', function(done) {
+      var stub = function() {
+        return {};
+      };
+      Ravel.module('./my-test-module.js');
+      mockery.registerMock(path.join(Ravel.cwd, 'my-test-module.js'), stub);
+      expect(Ravel._moduleFactories).to.have.property('myTestModule');
+      expect(Ravel._moduleFactories['myTestModule']).to.be.a('function');
+      Ravel._moduleFactories['myTestModule']();
+      done();
+    });
+
     it('should produce module factories which support dependency injection of client modules', function(done) {
       var stub1Instance = {
         method:function(){}


### PR DESCRIPTION
Modules with filenames including hyphens will be available for injection via camel case instead ('./modules/my-module.js' would be available as 'myModule').

Fixes #35