### PR TITLE
Object modules (which do not use DI) are now constructed immediately,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Business logic sits in plain old node.js modules, which are generally not networ
       var Cities = {};
       var c = ['Toronto', 'New York', 'Chicago'];
 
+      //Warning: Since dependency injection only takes
+      //place during Ravel.init, trying to use functions
+      //from your modules here won't work properly.
+
       Cities.getAllCities = function(callback) {
         // pretend we used async for something here
         // since we magically injected it above

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -31,17 +31,16 @@ module.exports = function(Ravel, moduleFactories, injector) {
         'Module with name \'' + name + '\' has already been registered.');
     }
 
-    var module = {};
+    var module;
 
-    //save uninitialized module to Ravel.modules
-    //so that it can be injected into other
-    //modules and lazily instantiated
-    Ravel.modules[name] = module;
+    var moduleInject = require(path.join(Ravel.cwd, modulePath));
 
-    //build module instantiation function
-    moduleFactories[name] = function() {
-      var moduleInject = require(path.join(Ravel.cwd, modulePath));
-      if (typeof(moduleInject) === 'function') {
+    if (typeof(moduleInject) === 'object') {
+      //this is not a module factory, so no need to perform dependency injection
+      module = moduleInject;
+    } else if (typeof(moduleInject) === 'function') {
+      module = {};
+      moduleFactories[name] = function() {
         //perform DI on module factory
         var temp = injector.inject({
           '$L': Ravel.Log.getLogger(name),
@@ -51,16 +50,17 @@ module.exports = function(Ravel, moduleFactories, injector) {
         for (var method in temp) {
           module[method] = temp[method];
         }
-      } else if (typeof(moduleInject) === 'object') {
-        //this is not a module factory, so we'll just copy
-        //module methods into stub uninitialized module
-        for (var existingMethod in moduleInject) {
-          module[existingMethod] = moduleInject[existingMethod];
-        }
-      } else {
-        throw new Ravel.ApplicationError.IllegalValue('Module with path ' +
-          modulePath + ' must be a factory function or an object.');
-      }
-    };
+      };
+    } else {
+      throw new Ravel.ApplicationError.IllegalValue('Module with path ' +
+        modulePath + ' must be a factory function or an object.');
+    }
+
+
+    //save potentially uninitialized module
+    //to Ravel.modules so that it can be
+    //injected into other modules and
+    //lazily instantiated
+    Ravel.modules[name] = module;
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "Sean McIntyre <smcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "contributors": [

--- a/test/core/test-module.js
+++ b/test/core/test-module.js
@@ -31,6 +31,7 @@ describe('Ravel', function() {
 
   describe('#module()', function() {
     it('should allow clients to register module files for instantiation in Ravel.start', function(done) {
+      mockery.registerMock(path.join(Ravel.cwd, './modules/test'), function(){});
       Ravel.module('./modules/test');
       expect(Ravel._moduleFactories).to.have.property('test');
       expect(Ravel._moduleFactories['test']).to.be.a('function');
@@ -38,6 +39,7 @@ describe('Ravel', function() {
     });
 
     it('should allow clients to register module files with an extension and still derive the correct name', function(done) {
+      mockery.registerMock(path.join(Ravel.cwd, './modules/test.js'), function(){});
       Ravel.module('./modules/test.js');
       expect(Ravel._moduleFactories).to.have.property('test');
       expect(Ravel._moduleFactories['test']).to.be.a('function');
@@ -45,6 +47,8 @@ describe('Ravel', function() {
     });
 
     it('should throw a Ravel.ApplicationError.DuplicateEntry error when clients attempt to register multiple modules with the same name', function(done) {
+      mockery.registerMock(path.join(Ravel.cwd, './modules/test'), function(){});
+      mockery.registerMock(path.join(Ravel.cwd, './more_modules/test'), function(){});
       var shouldThrow = function() {
         Ravel.module('./modules/test');
         Ravel.module('./more_modules/test');
@@ -76,8 +80,8 @@ describe('Ravel', function() {
           method: function() {}
         };
       };
-      Ravel.module('./test');
       mockery.registerMock(path.join(Ravel.cwd, 'test'), stub);
+      Ravel.module('./test');
       Ravel._moduleFactories['test']();
     });
 
@@ -85,8 +89,8 @@ describe('Ravel', function() {
       var stub = function() {
         return {};
       };
-      Ravel.module('./my-test-module.js');
       mockery.registerMock(path.join(Ravel.cwd, 'my-test-module.js'), stub);
+      Ravel.module('./my-test-module.js');
       expect(Ravel._moduleFactories).to.have.property('myTestModule');
       expect(Ravel._moduleFactories['myTestModule']).to.be.a('function');
       Ravel._moduleFactories['myTestModule']();
@@ -106,10 +110,10 @@ describe('Ravel', function() {
         done();
         return {};
       };
-      Ravel.module('./modules/test');
-      Ravel.module('./modules/test2');
       mockery.registerMock(path.join(Ravel.cwd, './modules/test'), stub1);
       mockery.registerMock(path.join(Ravel.cwd, './modules/test2'), stub2);
+      Ravel.module('./modules/test');
+      Ravel.module('./modules/test2');
       Ravel._moduleFactories['test']();
       Ravel._moduleFactories['test2']();
     });
@@ -128,9 +132,9 @@ describe('Ravel', function() {
           method: function() {}
         };
       };
-      Ravel.module('./test');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stubClientModule);
       mockery.registerMock('moment', stubMoment);
+      Ravel.module('./test');
       Ravel._moduleFactories['test']();
     });
 
@@ -138,8 +142,8 @@ describe('Ravel', function() {
       var stub = function(unknownModule) {
         expect(unknownModule).to.be.an('object');
       };
-      Ravel.module('./test');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stub);
+      Ravel.module('./test');
       var shouldThrow = function() {
         Ravel._moduleFactories['test']();
       };
@@ -151,19 +155,18 @@ describe('Ravel', function() {
       var stub = {
         method: function(){}
       };
-      Ravel.module('./test');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stub);
-      Ravel._moduleFactories['test']();
+      Ravel.module('./test');
+      expect(Ravel._moduleFactories).to.not.have.property('test');
       expect(Ravel.modules.test).to.deep.equal(stub);
       done();
     });
 
     it('should throw an ApplicationError.IllegalValue when a client attempts to register a module factory which is neither a function nor an object', function(done) {
       var stub = 'I am not a function or an object';
-      Ravel.module('./test');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stub);
       var shouldThrow = function() {
-        Ravel._moduleFactories['test']();
+        Ravel.module('./test');
       };
       expect(shouldThrow).to.throw(Ravel.ApplicationError.IllegalValue);
       done();
@@ -191,10 +194,10 @@ describe('Ravel', function() {
         done();
         return {};
       };
-      Ravel.module('./test1');
       mockery.registerMock(path.join(Ravel.cwd, './test1'), stub1);
-      Ravel.module('./test2');
       mockery.registerMock(path.join(Ravel.cwd, './test2'), stub2);
+      Ravel.module('./test1');
+      Ravel.module('./test2');
       Ravel._moduleFactories['test1']();
       Ravel._moduleFactories['test2']();
     });
@@ -217,12 +220,12 @@ describe('Ravel', function() {
         expect(test).to.equal(stub2Test);
         done();
       };
-      Ravel.module('./test');
-      Ravel.module('./test2');
-      Ravel.module('./test3');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stub1);
       mockery.registerMock(path.join(Ravel.cwd, './test2'), stub2);
       mockery.registerMock(path.join(Ravel.cwd, './test3'), stub3);
+      Ravel.module('./test');
+      Ravel.module('./test2');
+      Ravel.module('./test3');
       Ravel._moduleFactories['test']();
       Ravel._moduleFactories['test2']();
       Ravel._moduleFactories['test3']();
@@ -247,10 +250,10 @@ describe('Ravel', function() {
           }
         };
       };
-      Ravel.module('./test');
-      Ravel.module('./test2');
       mockery.registerMock(path.join(Ravel.cwd, './test'), stub1);
       mockery.registerMock(path.join(Ravel.cwd, './test2'), stub2);
+      Ravel.module('./test');
+      Ravel.module('./test2');
       Ravel._moduleFactories['test']();
       Ravel._moduleFactories['test2']();
       Ravel.modules.test2.method();

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -71,10 +71,10 @@ describe('Ravel', function() {
       });
     };
 
-    Ravel.module('users');
     mockery.registerMock(path.join(Ravel.cwd, 'users'), users);
-    Ravel.resource('usersResource');
+    Ravel.module('users');
     mockery.registerMock(path.join(Ravel.cwd, 'usersResource'), usersResource);
+    Ravel.resource('usersResource');
 
     //jshint unused:false
     favicon = sinon.stub();

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -81,12 +81,12 @@ describe('Ravel end-to-end test', function() {
         Ravel.set('express session secret', 'mysecret');
         Ravel.set('disable json vulnerability protection', true);
 
-        Ravel.module('users');
         mockery.registerMock(path.join(Ravel.cwd, 'users'), users);
-        Ravel.resource('usersResource');
+        Ravel.module('users');
         mockery.registerMock(path.join(Ravel.cwd, 'usersResource'), usersResource);
-        Ravel.routes('routes');
+        Ravel.resource('usersResource');
         mockery.registerMock(path.join(Ravel.cwd, 'routes'), routes);
+        Ravel.routes('routes');
         Ravel.init();
         agent = request.agent(Ravel._server);
         done();

--- a/test/util/test-injector.js
+++ b/test/util/test-injector.js
@@ -42,10 +42,10 @@ describe('Ravel', function() {
         done();
         return {};
       };
-      Ravel.module('test');
-      Ravel.module('test2');
       mockery.registerMock(path.join(Ravel.cwd, 'test'), stub1);
       mockery.registerMock(path.join(Ravel.cwd, 'test2'), stub2);
+      Ravel.module('test');
+      Ravel.module('test2');
       Ravel._moduleFactories['test']();
       Ravel._injector.inject({}, stub2);
     });
@@ -64,9 +64,9 @@ describe('Ravel', function() {
           method: function() {}
         };
       };
-      Ravel.module('test');
       mockery.registerMock(path.join(Ravel.cwd, 'test'), stubClientModule);
       mockery.registerMock('moment', stubMoment);
+      Ravel.module('test');
       Ravel._injector.inject({}, stubClientModule);
     });
 
@@ -74,8 +74,8 @@ describe('Ravel', function() {
       var stub = function(unknownModule) {
         expect(unknownModule).to.be.an('object');
       };
-      Ravel.module('test');
       mockery.registerMock(path.join(Ravel.cwd, 'test'), stub);
+      Ravel.module('test');
       try {
         Ravel._injector.inject({}, stub);
         done(new Error('It should be impossible to inject an unknown module or npm dependency'));
@@ -94,8 +94,8 @@ describe('Ravel', function() {
         expect(pseudoModule).to.equal(moduleMap.pseudoModule);
         done();
       };
-      Ravel.module('test');
       mockery.registerMock(path.join(Ravel.cwd, 'test'), stub);
+      Ravel.module('test');
       Ravel._injector.inject(moduleMap, stub);
     });
   });


### PR DESCRIPTION
… instead of via a virtually useless module factory function. Additionally, invalid modules are caught immediately now since we require() the module file right away.